### PR TITLE
Potential fix for code scanning alert no. 6: Incorrect conversion between integer types

### DIFF
--- a/api/sspanel/sspanel.go
+++ b/api/sspanel/sspanel.go
@@ -447,7 +447,11 @@ func (c *APIClient) ParseV2rayNodeResponse(nodeInfoResponse *NodeInfoResponse) (
 	if err != nil {
 		return nil, err
 	}
-	port := uint32(parsedPort)
+	if parsedPort < 1 || parsedPort > 65535 {
+		return nil, fmt.Errorf("invalid port %d: must be between 1 and 65535", parsedPort)
+	}
+	port16 := uint16(parsedPort)
+	port := uint32(port16)
 
 	parsedAlterID, err := strconv.ParseInt(serverConf[2], 10, 16)
 	if err != nil {
@@ -663,7 +667,11 @@ func (c *APIClient) ParseTrojanNodeResponse(nodeInfoResponse *NodeInfoResponse) 
 	if err != nil {
 		return nil, err
 	}
-	port := uint32(parsedPort)
+	if parsedPort < 1 || parsedPort > 65535 {
+		return nil, fmt.Errorf("invalid port %d: must be between 1 and 65535", parsedPort)
+	}
+	port16 := uint16(parsedPort)
+	port := uint32(port16)
 
 	serverConf := strings.Split(nodeInfoResponse.RawServerString, ";")
 	extraServerConf := strings.Split(serverConf[1], "|")
@@ -787,8 +795,12 @@ func (c *APIClient) ParseSSPanelNodeInfo(nodeInfoResponse *NodeInfoResponse) (*a
 	if err != nil {
 		return nil, err
 	}
+	if parsedPort < 1 || parsedPort > 65535 {
+		return nil, fmt.Errorf("invalid port %d: must be between 1 and 65535", parsedPort)
+	}
 
-	port := uint32(parsedPort)
+	port16 := uint16(parsedPort)
+	port := uint32(port16)
 
 	switch c.NodeType {
 	case "Shadowsocks":

--- a/service/tuic/config.go
+++ b/service/tuic/config.go
@@ -27,6 +27,9 @@ func (s *TuicService) buildSingBox() (*box.Box, string, error) {
 	if port == 0 {
 		return nil, "", fmt.Errorf("invalid port 0")
 	}
+	if port > 65535 {
+		return nil, "", fmt.Errorf("invalid port %d: must be between 1 and 65535", port)
+	}
 
 	certFile, keyFile, err := getOrIssueCert(s.config.CertConfig)
 	if err != nil {


### PR DESCRIPTION
Potential fix for [https://github.com/Mtoly/XrayRP/security/code-scanning/6](https://github.com/Mtoly/XrayRP/security/code-scanning/6)

In general, to safely convert between integer types of different sizes, you must ensure the value is within the target type’s range before casting. For ports, that means guaranteeing `1 <= port <= 65535` before converting to `uint16`. When using `strconv.ParseInt` with a bit size larger than the target type, you should either parse directly at the target size or perform explicit bounds checks.

For this codebase, the minimal and consistent fix is:

1. Keep parsing the port as now (`ParseInt(..., 32)` to `int64`) so behavior doesn’t change regarding parse errors.
2. Before assigning to `api.NodeInfo.Port` (a `uint32`) in each parser function, validate that the parsed value is in `[1, 65535]`. If it is not, return an error instead of silently truncating.
3. In `buildSingBox`, still ensure `port != 0`, but also guard the down‑cast to `uint16` by either:
   - checking `port <= 65535` and returning an error if not, or
   - constraining `api.NodeInfo.Port` to `uint16` at the source as in step 2, which guarantees it is always safe.  
   Since we’re adding checks at all port construction sites, the additional check in `buildSingBox` is mainly defensive but helps if any new code path ever sets `Port` differently.

Concretely:

- In `api/sspanel/sspanel.go`:
  - `ParseV2rayNodeResponse`: after `parsedPort` is parsed, add a bounds check `if parsedPort < 1 || parsedPort > 65535 { return nil, fmt.Errorf(...) }`. Then cast directly to `uint16` and assign to `api.NodeInfo.Port` as `uint32(port16)` to keep the public type unchanged but enforce the range.
  - `ParseTrojanNodeResponse`: same pattern as above.
  - The custom‑config path that parses `nodeConfig.OffsetPortNode`: same pattern as above.

- In `service/tuic/config.go`:
  - After retrieving `port := s.nodeInfo.Port`, add `if port > 65535 { return nil, "", fmt.Errorf("invalid port %d: must be <= 65535", port) }` before converting to `uint16` in the `listen` options. This makes the `uint16` cast provably safe and addresses all CodeQL variants for this sink.

No new packages are required; we only use `fmt` that is already imported where needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
