### PR TITLE
feat(controller): 添加 SpliceCopyEnable 配置以控制转发拼接特性

### DIFF
--- a/release/config/config.yml.example
+++ b/release/config/config.yml.example
@@ -66,6 +66,7 @@ Nodes:
           ProxyProtocolVer: 0 # Send PROXY protocol version, 0 for disable
       DisableLocalREALITYConfig: false  # disable local reality config
       EnableREALITY: false # Enable REALITY
+      SpliceCopyEnable: false # enable时开启Splice 特性，但会流量统计滞后
       REALITYConfigs:
         Dest: www.amazon.com:443 # Required, Same as fallback
         ProxyProtocolVer: 0 # Send PROXY protocol version, 0 for disable

--- a/service/controller/config.go
+++ b/service/controller/config.go
@@ -24,6 +24,7 @@ type Config struct {
 	DisableLocalREALITYConfig bool                             `mapstructure:"DisableLocalREALITYConfig"`
 	EnableREALITY             bool                             `mapstructure:"EnableREALITY"`
 	REALITYConfigs            *REALITYConfig                   `mapstructure:"REALITYConfigs"`
+	SpliceCopyEnable		  bool                             `mapstructure:"SpliceCopyEnable"`
 	WebSocketConfig           *WebSocketConfig                 `mapstructure:"WebSocketConfig"`
 }
 

--- a/service/controller/control.go
+++ b/service/controller/control.go
@@ -56,6 +56,7 @@ type dataPathWrapper struct {
 	sm          stats.Manager
 	limiter     *limiter.Limiter
 	routePolicy *api.PanelRoutePolicy
+	SpliceCopyEnable bool
 	logger      *log.Entry
 	// ruleMgr provides audit detection
 	ruleMgr interface {
@@ -98,9 +99,9 @@ func (w *dataPathWrapper) selectDispatchHandler(ctx context.Context) (outbound.H
 
 func (w *dataPathWrapper) Dispatch(ctx context.Context, link *transport.Link) {
 	// Force userland path to keep stats/limit in effect
-	if sess := session.InboundFromContext(ctx); sess != nil {
-		sess.CanSpliceCopy = 3
-	}
+		if sess := session.InboundFromContext(ctx); sess != nil && !w.SpliceCopyEnable {		
+			sess.CanSpliceCopy = 3
+		}
 
 	// --- FIRST: Enforce "same node in, same node out" semantics -------------
 	// This runs on EVERY connection so it must be as fast as possible.
@@ -206,6 +207,7 @@ func (c *Controller) addOutbound(config *core.OutboundHandlerConfig, tag string,
 		obm:         c.obm,
 		routePolicy: routePolicy,
 		logger:      c.logger.WithField("outbound_tag", tag),
+		SpliceCopyEnable: c.SpliceCopyEnable,
 	}
 	log.Infof("Adding outbound handler: configTag=%s handlerTag=%s wrapperTag=%s controllerTag=%s", config.Tag, handler.Tag(), wrapper.Tag(), tag)
 	if err := c.obm.AddHandler(context.Background(), wrapper); err != nil {

--- a/service/controller/controller.go
+++ b/service/controller/controller.go
@@ -60,6 +60,7 @@ type Controller struct {
 	wsRuntime              wsRuntimeLifecycle
 	syncCoordinatorFactory func(syncActionExecutor) syncCoordinatorLifecycle
 	wsRuntimeFactory       func(syncActionSubmitter) (wsRuntimeLifecycle, error)
+	SpliceCopyEnable       bool
 }
 
 type periodicTask struct {
@@ -117,6 +118,7 @@ func New(server *core.Instance, api api.API, config *Config, panelType string) *
 		return newSyncCoordinator(executor)
 	}
 	controller.wsRuntimeFactory = controller.newConfiguredWSRuntime
+	controller.SpliceCopyEnable = config.SpliceCopyEnable
 
 	return controller
 }


### PR DESCRIPTION
启用该配置后将开启Splice转发特性，但会导致流量统计滞后。本次修改同步更新了配置示例文件、配置结构体定义、控制器初始化逻辑以及连接分发逻辑，以适配新的配置项。