### PR TITLE
fix(acme): reject malformed account private keys safely

### DIFF
--- a/common/mylego/accounts_storage.go
+++ b/common/mylego/accounts_storage.go
@@ -1,6 +1,7 @@
 package mylego
 
 import (
+	"bytes"
 	"crypto"
 	"crypto/x509"
 	"encoding/json"
@@ -257,16 +258,30 @@ func loadPrivateKey(file string) (crypto.PrivateKey, error) {
 		return nil, err
 	}
 
-	keyBlock, _ := pem.Decode(keyBytes)
+	keyBlock, rest := pem.Decode(keyBytes)
+	if keyBlock == nil {
+		return nil, errors.New("decode account private key PEM: block not found")
+	}
+	if len(bytes.TrimSpace(rest)) != 0 {
+		return nil, errors.New("decode account private key PEM: trailing data")
+	}
 
 	switch keyBlock.Type {
 	case "RSA PRIVATE KEY":
-		return x509.ParsePKCS1PrivateKey(keyBlock.Bytes)
+		privateKey, err := x509.ParsePKCS1PrivateKey(keyBlock.Bytes)
+		if err != nil {
+			return nil, fmt.Errorf("parse RSA account private key: %w", err)
+		}
+		return privateKey, nil
 	case "EC PRIVATE KEY":
-		return x509.ParseECPrivateKey(keyBlock.Bytes)
+		privateKey, err := x509.ParseECPrivateKey(keyBlock.Bytes)
+		if err != nil {
+			return nil, fmt.Errorf("parse EC account private key: %w", err)
+		}
+		return privateKey, nil
+	default:
+		return nil, fmt.Errorf("unknown account private key type %q", keyBlock.Type)
 	}
-
-	return nil, errors.New("unknown private key type")
 }
 
 func tryRecoverRegistration(privateKey crypto.PrivateKey) (*registration.Resource, error) {

--- a/common/mylego/accounts_storage_private_key_test.go
+++ b/common/mylego/accounts_storage_private_key_test.go
@@ -1,0 +1,66 @@
+package mylego
+
+import (
+	"crypto"
+	"encoding/pem"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestLoadPrivateKeyRejectsMalformedPEMWithoutPanic(t *testing.T) {
+	keyPath := filepath.Join(t.TempDir(), "account.key")
+	if err := os.WriteFile(keyPath, []byte("not PEM"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	var (
+		key crypto.PrivateKey
+		err error
+	)
+	func() {
+		defer func() {
+			if recovered := recover(); recovered != nil {
+				t.Fatalf("loadPrivateKey panicked: %v", recovered)
+			}
+		}()
+		key, err = loadPrivateKey(keyPath)
+	}()
+	if key != nil {
+		t.Fatalf("loadPrivateKey returned key for malformed PEM: %T", key)
+	}
+	if err == nil || !strings.Contains(err.Error(), "block not found") {
+		t.Fatalf("loadPrivateKey error = %v, want PEM block error", err)
+	}
+}
+
+func TestLoadPrivateKeyRejectsTrailingPEMData(t *testing.T) {
+	keyPath := filepath.Join(t.TempDir(), "account.key")
+	if err := os.WriteFile(keyPath, append(pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: []byte("invalid")}), []byte("extra")...), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	key, err := loadPrivateKey(keyPath)
+	if key != nil {
+		t.Fatalf("loadPrivateKey returned key for trailing data: %T", key)
+	}
+	if err == nil || !strings.Contains(err.Error(), "trailing data") {
+		t.Fatalf("loadPrivateKey error = %v, want trailing-data error", err)
+	}
+}
+
+func TestLoadPrivateKeyRejectsUnsupportedPEMType(t *testing.T) {
+	keyPath := filepath.Join(t.TempDir(), "account.key")
+	if err := os.WriteFile(keyPath, pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: []byte("invalid")}), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	key, err := loadPrivateKey(keyPath)
+	if key != nil {
+		t.Fatalf("loadPrivateKey returned key for unsupported PEM type: %T", key)
+	}
+	if err == nil || !strings.Contains(err.Error(), "unknown account private key type") {
+		t.Fatalf("loadPrivateKey error = %v, want unsupported-type error", err)
+	}
+}


### PR DESCRIPTION
## Summary
- reject missing or malformed account-key PEM blocks without dereferencing nil
- reject trailing data and unsupported PEM block types with contextual errors
- preserve existing RSA and EC private-key parsing behavior
- add regression coverage proving malformed input does not panic

## Validation
- [x] `go test -count=1 ./common/mylego`
- [x] `go vet ./common/mylego`
- [x] `go build ./...`
- [x] malformed, trailing-data, and unsupported-type regression tests
- [ ] exact GitHub Actions checks on this PR

## Risk and rollback
The change affects only invalid or unsupported account private-key files. Revert the commit to restore the previous parser behavior if compatibility issues are observed.

## Intentionally excluded
Dependency upgrades, content certificate naming, documentation cleanup, and lifecycle refactors remain separate PRs.