### PR TITLE
fix(cert): isolate content certificates by runtime identity

### DIFF
--- a/common/mylego/content.go
+++ b/common/mylego/content.go
@@ -1,13 +1,15 @@
 package mylego
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
 )
 
-func ContentCert(certConfig *CertConfig) (string, string, error) {
+func ContentCert(certConfig *CertConfig, identity ...string) (string, string, error) {
 	if certConfig == nil {
 		return "", "", fmt.Errorf("CertConfig is nil")
 	}
@@ -19,7 +21,11 @@ func ContentCert(certConfig *CertConfig) (string, string, error) {
 	if err != nil {
 		return "", "", err
 	}
-	fileBase := safeContentCertFileBase(certConfig.CertDomain)
+	contentIdentity := strings.Join(identity, "\x00")
+	if strings.TrimSpace(contentIdentity) == "" {
+		contentIdentity = strings.Join([]string{certConfig.CertDomain, certConfig.CertContent, certConfig.KeyContent}, "\x00")
+	}
+	fileBase := contentCertFileBase(certConfig.CertDomain, contentIdentity)
 	certFile := filepath.Join(certDir, fileBase+".crt")
 	keyFile := filepath.Join(certDir, fileBase+".key")
 
@@ -53,6 +59,11 @@ func panelContentCertDir() (string, error) {
 		return "", err
 	}
 	return certDir, nil
+}
+
+func contentCertFileBase(domain, identity string) string {
+	hash := sha256.Sum256([]byte(identity))
+	return fmt.Sprintf("%s-%s", safeContentCertFileBase(domain), hex.EncodeToString(hash[:8]))
 }
 
 func safeContentCertFileBase(domain string) string {

--- a/common/mylego/content_test.go
+++ b/common/mylego/content_test.go
@@ -20,10 +20,8 @@ func TestContentCertWritesPanelProvidedPEM(t *testing.T) {
 		t.Fatalf("ContentCert returned error: %v", err)
 	}
 
-	wantCertFile := filepath.Join(configDir, "cert", "panel", "_.example.com_edge_443.crt")
-	wantKeyFile := filepath.Join(configDir, "cert", "panel", "_.example.com_edge_443.key")
-	if certFile != wantCertFile || keyFile != wantKeyFile {
-		t.Fatalf("unexpected cert files: cert=%q key=%q", certFile, keyFile)
+	if filepath.Base(certFile) == "_.example.com_edge_443.crt" || filepath.Base(keyFile) == "_.example.com_edge_443.key" {
+		t.Fatalf("expected content certificate paths to include an isolation suffix: cert=%q key=%q", certFile, keyFile)
 	}
 	assertFileContent(t, certFile, certConfig.CertContent)
 	assertFileContent(t, keyFile, certConfig.KeyContent)
@@ -48,8 +46,8 @@ func TestContentCertUsesFallbackFileBase(t *testing.T) {
 		t.Fatalf("ContentCert returned error: %v", err)
 	}
 
-	if certFile != filepath.Join(configDir, "cert", "panel", "panel.crt") || keyFile != filepath.Join(configDir, "cert", "panel", "panel.key") {
-		t.Fatalf("expected fallback panel file base, got cert=%q key=%q", certFile, keyFile)
+	if filepath.Base(certFile) == "panel.crt" || filepath.Base(keyFile) == "panel.key" {
+		t.Fatalf("expected fallback content certificate paths to include an isolation suffix, got cert=%q key=%q", certFile, keyFile)
 	}
 }
 
@@ -61,5 +59,44 @@ func assertFileContent(t *testing.T, path, want string) {
 	}
 	if string(content) != want {
 		t.Fatalf("unexpected file content for %s: %q", path, content)
+	}
+}
+
+func TestContentCertIsolatesIdentitiesAndSanitizedDomains(t *testing.T) {
+	configDir := t.TempDir()
+	t.Setenv("XRAY_LOCATION_CONFIG", configDir)
+	first := &CertConfig{CertDomain: "a/b", CertContent: "cert-A", KeyContent: "key-A"}
+	second := &CertConfig{CertDomain: "a?b", CertContent: "cert-B", KeyContent: "key-B"}
+	firstCert, firstKey, err := ContentCert(first, "panel-A", "node-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	secondCert, secondKey, err := ContentCert(second, "panel-B", "node-2")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if firstCert == secondCert || firstKey == secondKey {
+		t.Fatalf("content certificate identities collided: first=(%q,%q) second=(%q,%q)", firstCert, firstKey, secondCert, secondKey)
+	}
+	assertFileContent(t, firstCert, first.CertContent)
+	assertFileContent(t, firstKey, first.KeyContent)
+	assertFileContent(t, secondCert, second.CertContent)
+	assertFileContent(t, secondKey, second.KeyContent)
+}
+
+func TestContentCertIdentityIsStable(t *testing.T) {
+	configDir := t.TempDir()
+	t.Setenv("XRAY_LOCATION_CONFIG", configDir)
+	config := &CertConfig{CertDomain: "node.example.com", CertContent: "cert", KeyContent: "key"}
+	firstCert, firstKey, err := ContentCert(config, "panel", "node")
+	if err != nil {
+		t.Fatal(err)
+	}
+	secondCert, secondKey, err := ContentCert(config, "panel", "node")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if firstCert != secondCert || firstKey != secondKey {
+		t.Fatalf("content certificate identity is unstable: first=(%q,%q) second=(%q,%q)", firstCert, firstKey, secondCert, secondKey)
 	}
 }

--- a/common/mylego/ownership_test.go
+++ b/common/mylego/ownership_test.go
@@ -399,8 +399,10 @@ func TestContentCertRollsBackCertificateWhenKeyWriteFails(t *testing.T) {
 	if err := os.MkdirAll(certDir, 0o700); err != nil {
 		t.Fatal(err)
 	}
-	certPath := filepath.Join(certDir, "node.example.com.crt")
-	keyPath := filepath.Join(certDir, "node.example.com.key")
+	contentIdentity := strings.Join([]string{"node.example.com", "candidate-cert", "candidate-key"}, "\x00")
+	fileBase := contentCertFileBase("node.example.com", contentIdentity)
+	certPath := filepath.Join(certDir, fileBase+".crt")
+	keyPath := filepath.Join(certDir, fileBase+".key")
 	if err := os.WriteFile(certPath, []byte("last-known-good-cert"), filePerm); err != nil {
 		t.Fatal(err)
 	}

--- a/service/anytls/config.go
+++ b/service/anytls/config.go
@@ -105,7 +105,7 @@ func buildInboundTLSOptions(spec runtimeBuildSpec) (*option.InboundTLSOptions, e
 		return tlsOpt, nil
 	}
 
-	certFile, keyFile, err := getOrIssueCert(spec.certConfig)
+	certFile, keyFile, err := getOrIssueCert(spec.certConfig, spec.certificateIdentity)
 	if err != nil {
 		return nil, err
 	}
@@ -114,7 +114,7 @@ func buildInboundTLSOptions(spec runtimeBuildSpec) (*option.InboundTLSOptions, e
 	return tlsOpt, nil
 }
 
-func getOrIssueCert(certConfig *mylego.CertConfig) (string, string, error) {
+func getOrIssueCert(certConfig *mylego.CertConfig, certificateIdentity string) (string, string, error) {
 	if certConfig == nil {
 		return "", "", fmt.Errorf("CertConfig is nil")
 	}
@@ -125,7 +125,7 @@ func getOrIssueCert(certConfig *mylego.CertConfig) (string, string, error) {
 		}
 		return certConfig.CertFile, certConfig.KeyFile, nil
 	case "content":
-		return mylego.ContentCert(certConfig)
+		return mylego.ContentCert(certConfig, certificateIdentity)
 	case "dns":
 		lego, err := mylego.New(certConfig)
 		if err != nil {

--- a/service/anytls/service.go
+++ b/service/anytls/service.go
@@ -197,10 +197,11 @@ func (s *AnyTLSService) StartContext(parent context.Context) (err error) {
 
 	startupUsers := s.buildCandidateUserState(userInfo, nodeInfo)
 	boxInstance, inboundTag, err := s.buildRuntime(runtimeBuildSpec{
-		nodeInfo:   nodeInfo,
-		inboundTag: tag,
-		certConfig: cloneCertConfig(s.config.CertConfig),
-		authUsers:  append([]option.AnyTLSUser(nil), startupUsers.authUsers...),
+		nodeInfo:            nodeInfo,
+		inboundTag:          tag,
+		certConfig:          cloneCertConfig(s.config.CertConfig),
+		certificateIdentity: contentCertificateIdentity(clientInfo, nodeInfo, s.config.ListenIP),
+		authUsers:           append([]option.AnyTLSUser(nil), startupUsers.authUsers...),
 	})
 	if err != nil {
 		return fail(err)
@@ -518,11 +519,12 @@ func (s *AnyTLSService) reloadNodeWithCertificateLockedContext(ctx context.Conte
 
 	candidateCertConfig := deriveReloadCertConfig(oldCertConfig, oldNodeInfo, candidateNode)
 	spec := runtimeBuildSpec{
-		nodeInfo:       candidateNode,
-		inboundTag:     oldInboundTag,
-		certConfig:     candidateCertConfig,
-		certificatePEM: certificatePEM(renewal),
-		privateKeyPEM:  privateKeyPEM(renewal),
+		nodeInfo:            candidateNode,
+		inboundTag:          oldInboundTag,
+		certConfig:          candidateCertConfig,
+		certificateIdentity: contentCertificateIdentity(s.clientInfo, candidateNode, s.config.ListenIP),
+		certificatePEM:      certificatePEM(renewal),
+		privateKeyPEM:       privateKeyPEM(renewal),
 	}
 	candidateRuntime, _, err := s.buildReloadRuntime(spec)
 	if err != nil {
@@ -540,9 +542,10 @@ func (s *AnyTLSService) reloadNodeWithCertificateLockedContext(ctx context.Conte
 	}
 	restoreOldRuntime := func() (runtimeInstance, []runtimeInstance, error) {
 		restoredRuntime, _, restoreErr := s.buildReloadRuntime(runtimeBuildSpec{
-			nodeInfo:   oldNodeInfo,
-			inboundTag: oldInboundTag,
-			certConfig: oldCertConfig,
+			nodeInfo:            oldNodeInfo,
+			inboundTag:          oldInboundTag,
+			certConfig:          oldCertConfig,
+			certificateIdentity: contentCertificateIdentity(s.clientInfo, oldNodeInfo, s.config.ListenIP),
 		})
 		if restoreErr != nil {
 			return nil, nil, restoreErr
@@ -688,6 +691,13 @@ func cloneCertConfig(certConfig *mylego.CertConfig) *mylego.CertConfig {
 		}
 	}
 	return &cloned
+}
+
+func contentCertificateIdentity(clientInfo api.ClientInfo, nodeInfo *api.NodeInfo, listenIP string) string {
+	if nodeInfo == nil {
+		return fmt.Sprintf("%s:%d:%s", clientInfo.APIHost, clientInfo.NodeID, listenIP)
+	}
+	return fmt.Sprintf("%s:%d:%s:%d:%s", clientInfo.APIHost, clientInfo.NodeID, listenIP, nodeInfo.NodeID, nodeInfo.NodeType)
 }
 
 func cloneNodeInfo(nodeInfo *api.NodeInfo) *api.NodeInfo {

--- a/service/anytls/types.go
+++ b/service/anytls/types.go
@@ -25,12 +25,13 @@ type runtimeInstance interface {
 
 type runtimeFactory func(*AnyTLSService, runtimeBuildSpec) (runtimeInstance, string, error)
 type runtimeBuildSpec struct {
-	nodeInfo       *api.NodeInfo
-	inboundTag     string
-	certConfig     *mylego.CertConfig
-	certificatePEM []byte
-	privateKeyPEM  []byte
-	authUsers      []option.AnyTLSUser
+	nodeInfo            *api.NodeInfo
+	inboundTag          string
+	certConfig          *mylego.CertConfig
+	certificateIdentity string
+	certificatePEM      []byte
+	privateKeyPEM       []byte
+	authUsers           []option.AnyTLSUser
 }
 type reloadRuntimeFactory func(*AnyTLSService, runtimeBuildSpec) (runtimeInstance, string, error)
 type startRuntimeFunc func(runtimeInstance) error

--- a/service/hysteria2/config.go
+++ b/service/hysteria2/config.go
@@ -74,7 +74,7 @@ func (h *Hysteria2Service) buildServerConfigFor(spec serverBuildSpec) (*server.C
 			return nil, fmt.Errorf("load candidate tls certificate: %w", err)
 		}
 	} else {
-		certFile, keyFile, certErr := getOrIssueCert(spec.certConfig)
+		certFile, keyFile, certErr := getOrIssueCert(spec.certConfig, spec.certificateIdentity)
 		if certErr != nil {
 			packetConn.Close()
 			return nil, certErr
@@ -117,7 +117,7 @@ func (h *Hysteria2Service) buildServerConfigFor(spec serverBuildSpec) (*server.C
 
 // getOrIssueCert mirrors controller.getCertFile but is local to the hysteria2
 // package so we do not have to depend on unexported symbols.
-func getOrIssueCert(certConfig *mylego.CertConfig) (string, string, error) {
+func getOrIssueCert(certConfig *mylego.CertConfig, certificateIdentity string) (string, string, error) {
 	if certConfig == nil {
 		return "", "", fmt.Errorf("CertConfig is nil")
 	}
@@ -129,7 +129,7 @@ func getOrIssueCert(certConfig *mylego.CertConfig) (string, string, error) {
 		}
 		return certConfig.CertFile, certConfig.KeyFile, nil
 	case "content":
-		return mylego.ContentCert(certConfig)
+		return mylego.ContentCert(certConfig, certificateIdentity)
 	case "dns":
 		lego, err := mylego.New(certConfig)
 		if err != nil {

--- a/service/hysteria2/service.go
+++ b/service/hysteria2/service.go
@@ -275,8 +275,9 @@ func (h *Hysteria2Service) StartContext(parent context.Context) (err error) {
 	}
 
 	candidate, err := h.startReloadCandidateContext(ctx, serverBuildSpec{
-		nodeInfo:   nodeInfo,
-		certConfig: cloneCertConfig(h.config.CertConfig),
+		nodeInfo:            nodeInfo,
+		certConfig:          cloneCertConfig(h.config.CertConfig),
+		certificateIdentity: contentCertificateIdentity(clientInfo, nodeInfo, h.config.ListenIP),
 	})
 	if err != nil {
 		if candidate.runtime != nil {
@@ -630,10 +631,11 @@ func (h *Hysteria2Service) reloadNodeWithCertificateLockedContext(ctx context.Co
 
 	candidateCertConfig := deriveReloadCertConfig(oldCertConfig, oldNodeInfo, candidateNode)
 	candidateSpec := serverBuildSpec{
-		nodeInfo:       candidateNode,
-		certConfig:     candidateCertConfig,
-		certificatePEM: certificatePEM(renewal),
-		privateKeyPEM:  privateKeyPEM(renewal),
+		nodeInfo:            candidateNode,
+		certConfig:          candidateCertConfig,
+		certificateIdentity: contentCertificateIdentity(h.clientInfo, candidateNode, h.config.ListenIP),
+		certificatePEM:      certificatePEM(renewal),
+		privateKeyPEM:       privateKeyPEM(renewal),
 	}
 
 	closeRuntime := h.closeRuntime
@@ -664,8 +666,9 @@ func (h *Hysteria2Service) reloadNodeWithCertificateLockedContext(ctx context.Co
 		restoreCtx, restoreCancel := service.WithDefaultTimeout(context.WithoutCancel(ctx), service.DefaultStartTimeout)
 		defer restoreCancel()
 		restored, restoreErr := h.startReloadCandidateContext(restoreCtx, serverBuildSpec{
-			nodeInfo:   oldNodeInfo,
-			certConfig: oldCertConfig,
+			nodeInfo:            oldNodeInfo,
+			certConfig:          oldCertConfig,
+			certificateIdentity: contentCertificateIdentity(h.clientInfo, oldNodeInfo, h.config.ListenIP),
 		})
 		if restoreErr != nil {
 			if restored.runtime != nil {
@@ -989,6 +992,13 @@ func (h *Hysteria2Service) finishReloadWithOwnership(runtime runtimeServer, clea
 	if watcherDone != nil {
 		go h.watchRuntime(runtime, serve, cancelTraffic, watcherDone)
 	}
+}
+
+func contentCertificateIdentity(clientInfo api.ClientInfo, nodeInfo *api.NodeInfo, listenIP string) string {
+	if nodeInfo == nil {
+		return fmt.Sprintf("%s:%d:%s", clientInfo.APIHost, clientInfo.NodeID, listenIP)
+	}
+	return fmt.Sprintf("%s:%d:%s:%d:%s", clientInfo.APIHost, clientInfo.NodeID, listenIP, nodeInfo.NodeID, nodeInfo.NodeType)
 }
 
 func cloneNodeInfo(nodeInfo *api.NodeInfo) *api.NodeInfo {

--- a/service/hysteria2/types.go
+++ b/service/hysteria2/types.go
@@ -28,12 +28,13 @@ type runtimeServer interface {
 
 type serverConfigFactory func(*Hysteria2Service, serverBuildSpec) (*server.Config, error)
 type serverBuildSpec struct {
-	nodeInfo       *api.NodeInfo
-	certConfig     *mylego.CertConfig
-	certificatePEM []byte
-	privateKeyPEM  []byte
-	authGate       *runtimeAuthGate
-	trafficContext context.Context
+	nodeInfo            *api.NodeInfo
+	certConfig          *mylego.CertConfig
+	certificateIdentity string
+	certificatePEM      []byte
+	privateKeyPEM       []byte
+	authGate            *runtimeAuthGate
+	trafficContext      context.Context
 }
 type runtimeServerFactory func(*server.Config) (runtimeServer, error)
 type serveRuntimeFunc func(runtimeServer) error

--- a/service/tuic/config.go
+++ b/service/tuic/config.go
@@ -133,7 +133,7 @@ func buildInboundTLSOptions(spec runtimeBuildSpec) (*option.InboundTLSOptions, e
 		return tlsOpt, nil
 	}
 
-	certFile, keyFile, err := getOrIssueCert(spec.certConfig)
+	certFile, keyFile, err := getOrIssueCert(spec.certConfig, spec.certificateIdentity)
 	if err != nil {
 		return nil, err
 	}
@@ -142,7 +142,7 @@ func buildInboundTLSOptions(spec runtimeBuildSpec) (*option.InboundTLSOptions, e
 	return tlsOpt, nil
 }
 
-func getOrIssueCert(certConfig *mylego.CertConfig) (string, string, error) {
+func getOrIssueCert(certConfig *mylego.CertConfig, certificateIdentity string) (string, string, error) {
 	if certConfig == nil {
 		return "", "", fmt.Errorf("CertConfig is nil")
 	}
@@ -153,7 +153,7 @@ func getOrIssueCert(certConfig *mylego.CertConfig) (string, string, error) {
 		}
 		return certConfig.CertFile, certConfig.KeyFile, nil
 	case "content":
-		return mylego.ContentCert(certConfig)
+		return mylego.ContentCert(certConfig, certificateIdentity)
 	case "dns":
 		lego, err := mylego.New(certConfig)
 		if err != nil {

--- a/service/tuic/service.go
+++ b/service/tuic/service.go
@@ -202,10 +202,11 @@ func (s *TuicService) StartContext(parent context.Context) (err error) {
 
 	startupUsers := s.buildCandidateUserState(userInfo, nodeInfo)
 	boxInstance, inboundTag, err := s.buildRuntime(runtimeBuildSpec{
-		nodeInfo:   nodeInfo,
-		inboundTag: tag,
-		certConfig: cloneCertConfig(s.config.CertConfig),
-		authUsers:  append([]option.TUICUser(nil), startupUsers.authUsers...),
+		nodeInfo:            nodeInfo,
+		inboundTag:          tag,
+		certConfig:          cloneCertConfig(s.config.CertConfig),
+		certificateIdentity: contentCertificateIdentity(clientInfo, nodeInfo, s.config.ListenIP),
+		authUsers:           append([]option.TUICUser(nil), startupUsers.authUsers...),
 	})
 	if err != nil {
 		return fail(err)
@@ -523,11 +524,12 @@ func (s *TuicService) reloadNodeWithCertificateLockedContext(ctx context.Context
 
 	candidateCertConfig := deriveReloadCertConfig(oldCertConfig, oldNodeInfo, candidateNode)
 	spec := runtimeBuildSpec{
-		nodeInfo:       candidateNode,
-		inboundTag:     oldInboundTag,
-		certConfig:     candidateCertConfig,
-		certificatePEM: certificatePEM(renewal),
-		privateKeyPEM:  privateKeyPEM(renewal),
+		nodeInfo:            candidateNode,
+		inboundTag:          oldInboundTag,
+		certConfig:          candidateCertConfig,
+		certificateIdentity: contentCertificateIdentity(s.clientInfo, candidateNode, s.config.ListenIP),
+		certificatePEM:      certificatePEM(renewal),
+		privateKeyPEM:       privateKeyPEM(renewal),
 	}
 	candidateRuntime, _, err := s.buildReloadRuntime(spec)
 	if err != nil {
@@ -545,9 +547,10 @@ func (s *TuicService) reloadNodeWithCertificateLockedContext(ctx context.Context
 	}
 	restoreOldRuntime := func() (runtimeInstance, []runtimeInstance, error) {
 		restoredRuntime, _, restoreErr := s.buildReloadRuntime(runtimeBuildSpec{
-			nodeInfo:   oldNodeInfo,
-			inboundTag: oldInboundTag,
-			certConfig: oldCertConfig,
+			nodeInfo:            oldNodeInfo,
+			inboundTag:          oldInboundTag,
+			certConfig:          oldCertConfig,
+			certificateIdentity: contentCertificateIdentity(s.clientInfo, oldNodeInfo, s.config.ListenIP),
 		})
 		if restoreErr != nil {
 			return nil, nil, restoreErr
@@ -693,6 +696,13 @@ func cloneCertConfig(certConfig *mylego.CertConfig) *mylego.CertConfig {
 		}
 	}
 	return &cloned
+}
+
+func contentCertificateIdentity(clientInfo api.ClientInfo, nodeInfo *api.NodeInfo, listenIP string) string {
+	if nodeInfo == nil {
+		return fmt.Sprintf("%s:%d:%s", clientInfo.APIHost, clientInfo.NodeID, listenIP)
+	}
+	return fmt.Sprintf("%s:%d:%s:%d:%s", clientInfo.APIHost, clientInfo.NodeID, listenIP, nodeInfo.NodeID, nodeInfo.NodeType)
 }
 
 func cloneNodeInfo(nodeInfo *api.NodeInfo) *api.NodeInfo {

--- a/service/tuic/types.go
+++ b/service/tuic/types.go
@@ -25,12 +25,13 @@ type runtimeInstance interface {
 
 type runtimeFactory func(*TuicService, runtimeBuildSpec) (runtimeInstance, string, error)
 type runtimeBuildSpec struct {
-	nodeInfo       *api.NodeInfo
-	inboundTag     string
-	certConfig     *mylego.CertConfig
-	certificatePEM []byte
-	privateKeyPEM  []byte
-	authUsers      []option.TUICUser
+	nodeInfo            *api.NodeInfo
+	inboundTag          string
+	certConfig          *mylego.CertConfig
+	certificateIdentity string
+	certificatePEM      []byte
+	privateKeyPEM       []byte
+	authUsers           []option.TUICUser
 }
 type reloadRuntimeFactory func(*TuicService, runtimeBuildSpec) (runtimeInstance, string, error)
 type startRuntimeFunc func(runtimeInstance) error


### PR DESCRIPTION
## Summary
- add a stable, non-sensitive isolation suffix to panel-provided content certificate paths
- pass panel/node/runtime identity into AnyTLS, TUIC, and Hysteria2 certificate materialization
- retain deterministic paths for the same identity and prevent sanitized-domain collisions
- update transaction tests for the new path contract

## Validation
- [x] `go test -count=1 ./...`
- [x] `go vet ./...`
- [x] `go build ./...`
- [x] `go build -tags with_quic .`
- [x] targeted content certificate collision and stability tests
- [ ] exact GitHub Actions checks on this PR

## Risk and rollback
This changes only generated filenames for panel-provided content certificates. Existing file-mode and ACME paths are unchanged. Revert the commit to restore the previous naming behavior.

## Intentionally excluded
Dependency upgrades, ACME private-key parsing, documentation cleanup, and lifecycle refactors remain separate PRs.