### PR TITLE
fix(deps): update Hysteria to v2.12.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ Notable user-facing, compatibility, security, performance, and operational chang
 
 - Upgraded supported Go, Redis, Hysteria core/extras to v2.12.0, sing, sing-box, artifact, container, stale-issue, and signing dependencies; GitHub Actions remain pinned to full commit SHAs.
 - Updated the Go toolchain to 1.26.6, Hysteria core/extras to v2.12.1, sing to v0.8.13, sing-box to v1.13.18, and refreshed the pinned Alpine and CodeQL maintenance inputs.
+- Updated Hysteria core/extras to v2.12.2 as the latest available patch release; the existing GO-2026-5288 scan exception remains required because the vulnerability database still reports no fixed version.
 - Docker builds now pin both the Go builder and Alpine runtime images by readable version and multi-platform manifest digest.
 - Controller and machine runtimes now share one Applied node value deep-clone module, preserving nil/empty collection and custom address compatibility semantics.
 - Initial startup and hot reload now use the same mode-specific runtime configuration validation: static mode requires at least one `Nodes` entry, while enabled `MachineConfig` is valid with no static `Nodes`.

--- a/docs/dependency-review-2026-08-17.md
+++ b/docs/dependency-review-2026-08-17.md
@@ -88,3 +88,13 @@ now matches that policy.
 4. Update Hysteria and sing-box in a separate dependency batch, then run
    protocol lifecycle, QUIC, reload, panel compatibility, and release tests.
 5. Verify Docker image provenance and the pinned Action SHAs before merging.
+
+## Patch follow-up — 2026-09-09
+
+- Updated `github.com/apernet/hysteria/core/v2` and
+  `github.com/apernet/hysteria/extras/v2` from `v2.12.1` to `v2.12.2`.
+- `go test -count=1 ./service/hysteria2 ./service/controller` passed.
+- `govulncheck v1.6.0 ./...` still reports only reachable `GO-2026-5288` for
+  `core/v2@v2.12.2`; the database continues to publish no fixed version.
+- The existing `RequestHook: nil` defense-in-depth test and exact CI exception
+  remain in force; this patch update does not claim the advisory is cleared.

--- a/go.mod
+++ b/go.mod
@@ -4,8 +4,8 @@ go 1.26.6
 
 require (
 	dario.cat/mergo v1.0.2
-	github.com/apernet/hysteria/core/v2 v2.12.1
-	github.com/apernet/hysteria/extras/v2 v2.12.1
+	github.com/apernet/hysteria/core/v2 v2.12.2
+	github.com/apernet/hysteria/extras/v2 v2.12.2
 	github.com/bitly/go-simplejson v0.5.1
 	github.com/eko/gocache/lib/v4 v4.2.4
 	github.com/eko/gocache/store/go_cache/v4 v4.2.5

--- a/go.sum
+++ b/go.sum
@@ -751,10 +751,10 @@ github.com/anytls/sing-anytls v0.0.11/go.mod h1:7rjN6IukwysmdusYsrV51Fgu1uW6vsrd
 github.com/apache/arrow/go/v10 v10.0.1/go.mod h1:YvhnlEePVnBS4+0z3fhPfUy7W1Ikj0Ih0vcRo/gZ1M0=
 github.com/apache/arrow/go/v11 v11.0.0/go.mod h1:Eg5OsL5H+e299f7u5ssuXsuHQVEGC4xei5aX110hRiI=
 github.com/apache/thrift v0.16.0/go.mod h1:PHK3hniurgQaNMZYaCLEqXKsYK8upmhPbmdP2FXSqgU=
-github.com/apernet/hysteria/core/v2 v2.12.1 h1:7jA/jSC+1tFP8Z9COzI0AdT1p9c0SY7D8vngRd1YX7s=
-github.com/apernet/hysteria/core/v2 v2.12.1/go.mod h1:YVOel66fPGf9dO2rz/9Bsu6yChyMe7gSmYagAYfPOGE=
-github.com/apernet/hysteria/extras/v2 v2.12.1 h1:pLtKedlKSUHGCuUxeVaOOI2UUPlj/5DaqXm01FGrF7U=
-github.com/apernet/hysteria/extras/v2 v2.12.1/go.mod h1:QzIFayY1vN8qxX/VpZF+7CGguFpbKDvxbSRp9FmX9V4=
+github.com/apernet/hysteria/core/v2 v2.12.2 h1:7dqQqVUp//J6q5fDlOW/v/IkCC/ZGXU02NrEOWYh7YU=
+github.com/apernet/hysteria/core/v2 v2.12.2/go.mod h1:YVOel66fPGf9dO2rz/9Bsu6yChyMe7gSmYagAYfPOGE=
+github.com/apernet/hysteria/extras/v2 v2.12.2 h1:Z69dokL2grqTUt2KDIvJ+0sfqBtN1d1JIVo+KRj8WDE=
+github.com/apernet/hysteria/extras/v2 v2.12.2/go.mod h1:QzIFayY1vN8qxX/VpZF+7CGguFpbKDvxbSRp9FmX9V4=
 github.com/apernet/quic-go v0.61.1-0.20260806010916-184d081eef3e h1:5mgtR5gwIgBKMiGI1QdXldZZ+SNor06Nbu1wCBulQBg=
 github.com/apernet/quic-go v0.61.1-0.20260806010916-184d081eef3e/go.mod h1:x7qxEvX6MCVtDuBKHj3E+88+BtrbEMuAL5qGUKItjW8=
 github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e/go.mod h1:3U/XgcO3hCbHZ8TKRvWD2dDTCfh9M9ya+I9JpbB7O8o=


### PR DESCRIPTION
## Summary
- update Hysteria core and extras from v2.12.1 to v2.12.2
- remove stale v2.12.1 checksums
- record the vulnerability-scan result and retain the existing exact GO-2026-5288 CI exception

## Verification
- `go mod tidy -diff`
- `go mod verify`
- `go test -count=1 ./service/hysteria2 ./service/controller ./service/internal/specialruntime`
- `go test -count=1 ./...`
- `go vet ./...`
- `go build ./...`
- `go build -tags with_quic .`
- `go test -race -count=1 ./service/hysteria2 ./service/controller ./service/internal/specialruntime` (Debian WSL2, CGO_ENABLED=1)
- `git diff --check`

`govulncheck v1.6.0 ./...` still reports only `GO-2026-5288` for `core/v2@v2.12.2`; the database reports no fixed version, and the existing `RequestHook: nil` defense-in-depth test plus exact CI exception remain in force.

Do not merge automatically; this PR is intentionally left for review.