### PR TITLE
test(runtime): cover host task rollback contract

### DIFF
--- a/service/internal/specialruntime/runtime_host_test.go
+++ b/service/internal/specialruntime/runtime_host_test.go
@@ -153,3 +153,43 @@ func TestRuntimeHostAggregatesStopAndJoinErrors(t *testing.T) {
 		t.Fatalf("CloseStoppedContext() error = %v, want both runtime errors", err)
 	}
 }
+
+func TestRuntimeHostTaskStartFailureRollsBackRuntimeAndTasks(t *testing.T) {
+	startErr := errors.New("task start failed")
+	stopErr := errors.New("task stop failed")
+	waitErr := errors.New("task wait failed")
+	runtimeStopErr := errors.New("runtime stop failed")
+	runtimeJoinErr := errors.New("runtime join failed")
+	events := []string{}
+	tasks := NewTasks()
+	tasks.Add(&recordingTask{name: "first", events: &events, waitErr: waitErr})
+	tasks.Add(&recordingTask{name: "second", events: &events, startErr: startErr, stopErr: stopErr})
+	host := NewRuntimeHost(tasks, RuntimeHostCallbacks{
+		Stop: func(context.Context) error {
+			events = append(events, "runtime-stop")
+			return runtimeStopErr
+		},
+		Join: func(context.Context) error {
+			events = append(events, "runtime-join")
+			return runtimeJoinErr
+		},
+	})
+
+	err := host.StartContext(context.Background())
+	for _, want := range []error{startErr, stopErr, waitErr, runtimeStopErr, runtimeJoinErr} {
+		if !errors.Is(err, want) {
+			t.Fatalf("StartContext() error = %v, want joined %v", err, want)
+		}
+	}
+	if !StartCleanupFailed(err) {
+		t.Fatalf("StartContext() error = %v, want cleanup failure classification", err)
+	}
+	wantEvents := []string{
+		"start:first", "start:second",
+		"stop:second", "stop:first",
+		"runtime-stop", "wait:second", "wait:first", "runtime-join",
+	}
+	if !reflect.DeepEqual(events, wantEvents) {
+		t.Fatalf("events = %v, want %v", events, wantEvents)
+	}
+}


### PR DESCRIPTION
## Summary
- add an integration contract test for RuntimeHost task-start failures
- verify joined start and cleanup errors remain observable
- verify reverse task stop, runtime stop, task wait, and runtime join ordering

## Verification
- `go test -count=1 ./service/internal/specialruntime`
- `go test -count=1 ./...`
- `go vet ./...`
- `go build ./...`
- `go test -race -count=1 ./service/internal/specialruntime` (Debian WSL2, CGO_ENABLED=1)
- `git diff --check`

Default branch is unchanged. This PR is intentionally left open for review and is not auto-merged.