### PR TITLE
test(runtime): cover detached cleanup context

### DIFF
--- a/service/internal/specialruntime/runtime_host_test.go
+++ b/service/internal/specialruntime/runtime_host_test.go
@@ -193,3 +193,38 @@ func TestRuntimeHostTaskStartFailureRollsBackRuntimeAndTasks(t *testing.T) {
 		t.Fatalf("events = %v, want %v", events, wantEvents)
 	}
 }
+
+func TestRuntimeHostRuntimeStartFailureUsesDetachedCleanupContext(t *testing.T) {
+	startErr := errors.New("runtime not ready")
+	parent, cancelParent := context.WithCancel(context.Background())
+	defer cancelParent()
+	startCanceled := false
+	stopCanceled := true
+	joinCanceled := true
+	host := NewRuntimeHost(nil, RuntimeHostCallbacks{
+		Start: func(ctx context.Context) error {
+			cancelParent()
+			startCanceled = ctx.Err() != nil
+			return startErr
+		},
+		Stop: func(ctx context.Context) error {
+			stopCanceled = ctx.Err() != nil
+			return nil
+		},
+		Join: func(ctx context.Context) error {
+			joinCanceled = ctx.Err() != nil
+			return nil
+		},
+	})
+
+	err := host.StartContext(parent)
+	if !errors.Is(err, startErr) {
+		t.Fatalf("StartContext() error = %v, want %v", err, startErr)
+	}
+	if !startCanceled {
+		t.Fatal("runtime start callback did not observe parent cancellation")
+	}
+	if stopCanceled || joinCanceled {
+		t.Fatalf("cleanup callbacks received canceled context: stop=%v join=%v", stopCanceled, joinCanceled)
+	}
+}


### PR DESCRIPTION
## Summary
- add a RuntimeHost contract test for canceled runtime startup
- verify the runtime start callback observes parent cancellation
- verify detached cleanup context remains usable for Stop and Join callbacks

## Verification
- `go test -count=1 ./service/internal/specialruntime`
- `go test -count=1 ./...`
- `go vet ./...`
- `go build ./...`
- `go test -race -count=1 ./service/internal/specialruntime` (Debian WSL2, CGO_ENABLED=1)
- `git diff --check`

Default branch is unchanged. This PR is intentionally left open for review and is not auto-merged.