### PR TITLE
test(runtime): cover producer shutdown ordering

### DIFF
--- a/service/internal/specialruntime/runtime_host_test.go
+++ b/service/internal/specialruntime/runtime_host_test.go
@@ -228,3 +228,37 @@ func TestRuntimeHostRuntimeStartFailureUsesDetachedCleanupContext(t *testing.T) 
 		t.Fatalf("cleanup callbacks received canceled context: stop=%v join=%v", stopCanceled, joinCanceled)
 	}
 }
+
+func TestRuntimeHostStopsProducersBeforeRuntimeShutdown(t *testing.T) {
+	events := []string{}
+	tasks := NewTasks()
+	tasks.Add(&recordingTask{name: "first", events: &events})
+	tasks.Add(&recordingTask{name: "second", events: &events})
+	host := NewRuntimeHost(tasks, RuntimeHostCallbacks{
+		Stop: func(context.Context) error {
+			events = append(events, "runtime-stop")
+			return nil
+		},
+		Join: func(context.Context) error {
+			events = append(events, "runtime-join")
+			return nil
+		},
+	})
+
+	if err := host.StopProducersContext(context.Background()); err != nil {
+		t.Fatalf("StopProducersContext() error = %v", err)
+	}
+	if want := []string{"stop:second", "stop:first"}; !reflect.DeepEqual(events, want) {
+		t.Fatalf("events after StopProducersContext() = %v, want %v", events, want)
+	}
+	if err := host.CloseStoppedContext(context.Background()); err != nil {
+		t.Fatalf("CloseStoppedContext() error = %v", err)
+	}
+	want := []string{
+		"stop:second", "stop:first", "runtime-stop",
+		"wait:second", "wait:first", "runtime-join",
+	}
+	if !reflect.DeepEqual(events, want) {
+		t.Fatalf("events after shutdown = %v, want %v", events, want)
+	}
+}


### PR DESCRIPTION
## Summary
- cover the split between producer shutdown and runtime shutdown
- verify reverse-order producer stops happen exactly once before runtime stop
- verify task waits precede runtime join after `CloseStoppedContext`

## Verification
- `go test -count=1 ./service/internal/specialruntime -run '^TestRuntimeHostStopsProducersBeforeRuntimeShutdown$'`
- `go test -count=1 ./service/internal/specialruntime`
- `go test -p 1 -count=1 ./...` (passed on the second run; the first run had transient ETag assertions in four API packages, which passed when rerun individually)
- `go vet ./...`
- `go build ./...`
- `go build -tags with_quic .`
- `git diff --check`
- local race attempt recorded: Windows environment lacks GCC for `CGO_ENABLED=1`; Linux CI remains authoritative

Default branch is unchanged. This PR is intentionally left open and is not auto-merged.