### PR TITLE
fix(runtime): detach rollback cleanup context

### DIFF
--- a/service/internal/specialruntime/runtime_host.go
+++ b/service/internal/specialruntime/runtime_host.go
@@ -82,10 +82,12 @@ func (h *RuntimeHost) RollbackContext(ctx context.Context) error {
 	if h == nil {
 		return nil
 	}
+	cleanupCtx, cancel := service.CleanupContext(ctx)
+	defer cancel()
 	if h.tasks != nil {
-		return h.tasks.RollbackContext(ctx, h.runtimeShutdown())
+		return h.tasks.RollbackContext(cleanupCtx, h.runtimeShutdown())
 	}
-	return h.closeRuntimeContext(ctx)
+	return h.closeRuntimeContext(cleanupCtx)
 }
 
 func (h *RuntimeHost) runtimeShutdown() RuntimeShutdown {

--- a/service/internal/specialruntime/runtime_host_test.go
+++ b/service/internal/specialruntime/runtime_host_test.go
@@ -358,3 +358,71 @@ func TestRuntimeHostTaskStartFailureUsesDetachedCleanupContext(t *testing.T) {
 		t.Fatalf("events = %v, want %v", events, want)
 	}
 }
+
+type rollbackContextTask struct {
+	events *[]string
+}
+
+func (t *rollbackContextTask) Start() error { return nil }
+func (t *rollbackContextTask) Close() error { return errors.New("legacy Close called") }
+
+func (t *rollbackContextTask) StopContext(ctx context.Context) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	if ctx.Value(contextMarkerKey{}) != "marker" {
+		return errors.New("stop context marker missing")
+	}
+	*t.events = append(*t.events, "task-stop")
+	return nil
+}
+
+func (t *rollbackContextTask) WaitContext(ctx context.Context) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	if ctx.Value(contextMarkerKey{}) != "marker" {
+		return errors.New("wait context marker missing")
+	}
+	*t.events = append(*t.events, "task-wait")
+	return nil
+}
+
+func TestRuntimeHostRollbackUsesDetachedCleanupContext(t *testing.T) {
+	parent, cancel := context.WithCancel(context.Background())
+	ctx := context.WithValue(parent, contextMarkerKey{}, "marker")
+	cancel()
+	events := []string{}
+	tasks := NewTasks()
+	tasks.Add(&rollbackContextTask{events: &events})
+	host := NewRuntimeHost(tasks, RuntimeHostCallbacks{
+		Stop: func(ctx context.Context) error {
+			if err := ctx.Err(); err != nil {
+				return err
+			}
+			if ctx.Value(contextMarkerKey{}) != "marker" {
+				return errors.New("runtime stop context marker missing")
+			}
+			events = append(events, "runtime-stop")
+			return nil
+		},
+		Join: func(ctx context.Context) error {
+			if err := ctx.Err(); err != nil {
+				return err
+			}
+			if ctx.Value(contextMarkerKey{}) != "marker" {
+				return errors.New("runtime join context marker missing")
+			}
+			events = append(events, "runtime-join")
+			return nil
+		},
+	})
+
+	if err := host.RollbackContext(ctx); err != nil {
+		t.Fatalf("RollbackContext() error = %v", err)
+	}
+	want := []string{"task-stop", "runtime-stop", "task-wait", "runtime-join"}
+	if !reflect.DeepEqual(events, want) {
+		t.Fatalf("events = %v, want %v", events, want)
+	}
+}


### PR DESCRIPTION
## Summary
- detach rollback cleanup from a canceled activation context
- preserve context values while allowing task stop/wait and runtime stop/join to finish
- add a regression test for the Hysteria2-style post-start rollback path

## Verification
- `go test -count=1 ./service/internal/specialruntime -run '^TestRuntimeHostRollbackUsesDetachedCleanupContext$'`
- `go test -count=1 ./service/internal/specialruntime`
- `go test -p 1 -count=1 ./...`
- `go vet ./...`
- `go build ./...`
- `go build -tags with_quic .`
- `git diff --check`
- local race attempts recorded: Windows environment lacks GCC for `CGO_ENABLED=1`; Linux CI remains authoritative

Default branch is unchanged. This PR is intentionally left open and is not auto-merged.