### PR TITLE
fix(runtime): rollback when startup context cancels after start

### DIFF
--- a/service/internal/specialruntime/runtime_host.go
+++ b/service/internal/specialruntime/runtime_host.go
@@ -46,11 +46,26 @@ func (h *RuntimeHost) StartContext(ctx context.Context) error {
 			cancel()
 			return &runtimeStartFailure{startErr: err, cleanupErr: cleanupErr}
 		}
+		if err := ctx.Err(); err != nil {
+			cleanupCtx, cancel := service.CleanupContext(ctx)
+			cleanupErr := h.closeRuntimeContext(cleanupCtx)
+			cancel()
+			return &runtimeStartFailure{startErr: err, cleanupErr: cleanupErr}
+		}
 	}
 	if h.tasks == nil {
 		return nil
 	}
-	return h.tasks.StartContext(ctx, h.runtimeShutdown())
+	if err := h.tasks.StartContext(ctx, h.runtimeShutdown()); err != nil {
+		return err
+	}
+	if err := ctx.Err(); err != nil {
+		cleanupCtx, cancel := service.CleanupContext(ctx)
+		cleanupErr := h.tasks.RollbackContext(cleanupCtx, h.runtimeShutdown())
+		cancel()
+		return &taskStartFailure{startErr: err, cleanupErr: cleanupErr}
+	}
+	return nil
 }
 
 // StopProducersContext stops periodic task producers without touching the

--- a/service/internal/specialruntime/runtime_host_test.go
+++ b/service/internal/specialruntime/runtime_host_test.go
@@ -426,3 +426,140 @@ func TestRuntimeHostRollbackUsesDetachedCleanupContext(t *testing.T) {
 		t.Fatalf("events = %v, want %v", events, want)
 	}
 }
+
+type cancelAfterSuccessfulStartTask struct {
+	events       *[]string
+	cancelParent context.CancelFunc
+}
+
+func (t *cancelAfterSuccessfulStartTask) Start() error {
+	return errors.New("legacy Start called")
+}
+
+func (t *cancelAfterSuccessfulStartTask) Close() error {
+	return errors.New("legacy Close called")
+}
+
+func (t *cancelAfterSuccessfulStartTask) StartContext(ctx context.Context) error {
+	if ctx.Value(contextMarkerKey{}) != "marker" {
+		return errors.New("start context marker missing")
+	}
+	*t.events = append(*t.events, "task-start")
+	t.cancelParent()
+	return nil
+}
+
+func (t *cancelAfterSuccessfulStartTask) StopContext(ctx context.Context) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	if ctx.Value(contextMarkerKey{}) != "marker" {
+		return errors.New("stop context marker missing")
+	}
+	*t.events = append(*t.events, "task-stop")
+	return nil
+}
+
+func (t *cancelAfterSuccessfulStartTask) WaitContext(ctx context.Context) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	if ctx.Value(contextMarkerKey{}) != "marker" {
+		return errors.New("wait context marker missing")
+	}
+	*t.events = append(*t.events, "task-wait")
+	return nil
+}
+
+func TestRuntimeHostRollsBackWhenStartupContextCancelsAfterTaskStart(t *testing.T) {
+	parent, cancelParent := context.WithCancel(context.Background())
+	ctx := context.WithValue(parent, contextMarkerKey{}, "marker")
+	events := []string{}
+	tasks := NewTasks()
+	tasks.Add(&cancelAfterSuccessfulStartTask{events: &events, cancelParent: cancelParent})
+	host := NewRuntimeHost(tasks, RuntimeHostCallbacks{
+		Stop: func(ctx context.Context) error {
+			if err := ctx.Err(); err != nil {
+				return err
+			}
+			if ctx.Value(contextMarkerKey{}) != "marker" {
+				return errors.New("runtime stop context marker missing")
+			}
+			events = append(events, "runtime-stop")
+			return nil
+		},
+		Join: func(ctx context.Context) error {
+			if err := ctx.Err(); err != nil {
+				return err
+			}
+			if ctx.Value(contextMarkerKey{}) != "marker" {
+				return errors.New("runtime join context marker missing")
+			}
+			events = append(events, "runtime-join")
+			return nil
+		},
+	})
+
+	err := host.StartContext(ctx)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("StartContext() error = %v, want context.Canceled", err)
+	}
+	if StartCleanupFailed(err) {
+		t.Fatalf("StartContext() error = %v, cleanup unexpectedly failed", err)
+	}
+	want := []string{"task-start", "task-stop", "runtime-stop", "task-wait", "runtime-join"}
+	if !reflect.DeepEqual(events, want) {
+		t.Fatalf("events = %v, want %v", events, want)
+	}
+}
+
+func TestRuntimeHostRollsBackWhenStartupContextCancelsAfterRuntimeStart(t *testing.T) {
+	parent, cancelParent := context.WithCancel(context.Background())
+	ctx := context.WithValue(parent, contextMarkerKey{}, "marker")
+	events := []string{}
+	host := NewRuntimeHost(nil, RuntimeHostCallbacks{
+		Start: func(ctx context.Context) error {
+			if ctx.Value(contextMarkerKey{}) != "marker" {
+				return errors.New("runtime start context marker missing")
+			}
+			events = append(events, "runtime-start")
+			cancelParent()
+			return nil
+		},
+		Stop: func(ctx context.Context) error {
+			if err := ctx.Err(); err != nil {
+				return err
+			}
+			if ctx.Value(contextMarkerKey{}) != "marker" {
+				return errors.New("runtime stop context marker missing")
+			}
+			events = append(events, "runtime-stop")
+			return nil
+		},
+		Join: func(ctx context.Context) error {
+			if err := ctx.Err(); err != nil {
+				return err
+			}
+			if ctx.Value(contextMarkerKey{}) != "marker" {
+				return errors.New("runtime join context marker missing")
+			}
+			events = append(events, "runtime-join")
+			return nil
+		},
+	})
+
+	err := host.StartContext(ctx)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("StartContext() error = %v, want context.Canceled", err)
+	}
+	if !RuntimeStartFailed(err) {
+		t.Fatalf("StartContext() error = %v, want runtime-start failure classification", err)
+	}
+	if StartCleanupFailed(err) {
+		t.Fatalf("StartContext() error = %v, cleanup unexpectedly failed", err)
+	}
+	want := []string{"runtime-start", "runtime-stop", "runtime-join"}
+	if !reflect.DeepEqual(events, want) {
+		t.Fatalf("events = %v, want %v", events, want)
+	}
+}


### PR DESCRIPTION
## Summary

- Treat cancellation observed immediately after a successful runtime start as a startup failure.
- Roll back the runtime with the detached cleanup context before returning the cancellation error.
- Treat cancellation observed after all periodic tasks report successful startup the same way, preserving task-stop → runtime-stop → task-wait → runtime-join ordering.
- Add regression coverage for both runtime-start and task-start paths.

## Why

A startup callback or task can return success while canceling the parent context. Previously `RuntimeHost.StartContext` returned nil in that window, allowing callers to publish a runtime whose startup context had already been canceled and leaving owned resources running.

## Validation

- `go test -count=1 ./service/internal/specialruntime -run '^TestRuntimeHostRollsBackWhenStartupContextCancelsAfter(Runtime|Task)Start$'`
- `go test -count=1 ./service/internal/specialruntime`
- `go test -p 1 -count=1 ./...`
- `go vet ./...`
- `go build ./...`
- `go build -tags with_quic .`
- `git diff --check`
- Linux CI is expected to provide race-detector evidence; local Windows race execution is unavailable because cgo requires GCC, which is not installed.

## Risk and rollback

This is a package-private lifecycle change limited to `service/internal/specialruntime`. The existing startup error classifications and cleanup ordering are preserved. Revert commit `d4d6bbe9f7abae6e75402123e6b5d5ca26063d48` to roll back.

## Follow-up intentionally excluded

Protocol-specific replacement policy, Hysteria2 readiness/authentication/port-hop behavior, and public service interfaces are unchanged.