### PR TITLE
fix(runtime): reject canceled taskless startup context

### DIFF
--- a/service/internal/specialruntime/runtime_host.go
+++ b/service/internal/specialruntime/runtime_host.go
@@ -54,7 +54,7 @@ func (h *RuntimeHost) StartContext(ctx context.Context) error {
 		}
 	}
 	if h.tasks == nil {
-		return nil
+		return ctx.Err()
 	}
 	if err := h.tasks.StartContext(ctx, h.runtimeShutdown()); err != nil {
 		return err

--- a/service/internal/specialruntime/runtime_host_test.go
+++ b/service/internal/specialruntime/runtime_host_test.go
@@ -563,3 +563,13 @@ func TestRuntimeHostRollsBackWhenStartupContextCancelsAfterRuntimeStart(t *testi
 		t.Fatalf("events = %v, want %v", events, want)
 	}
 }
+
+func TestRuntimeHostRejectsCanceledContextBeforeTasklessStart(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	host := NewRuntimeHost(nil, RuntimeHostCallbacks{})
+	if err := host.StartContext(ctx); !errors.Is(err, context.Canceled) {
+		t.Fatalf("StartContext() error = %v, want context.Canceled", err)
+	}
+}


### PR DESCRIPTION
## Summary

- Return the startup context error for a taskless `RuntimeHost` after the existing pre-start/runtime-start checks.
- Preserve the existing task-backed canceled-context rollback path.
- Add a regression test for a canceled context before taskless startup.

## Why

A taskless host with no runtime `Start` callback previously returned nil even when its startup context was already canceled. This allowed a caller to treat a canceled startup as successful. The change closes that gap without changing the existing detached cleanup behavior for task-backed startup or runtime-start failures.

## Validation

- `go test -count=1 ./service/internal/specialruntime -run '^TestRuntimeHost(RejectsCanceledContextBeforeTasklessStart|DelegatesCanceledExternalRuntimeToTaskRollback)$'`
- `go test -count=1 ./service/internal/specialruntime`
- `go test -p 1 -count=1 ./...`
- `go vet ./...`
- `go build ./...`
- `go build -tags with_quic .`
- `git diff --check`
- Local Windows race execution remains unavailable because cgo requires GCC, which is not installed; CI provides Linux race evidence.

## Risk and rollback

Package-private lifecycle fix limited to `service/internal/specialruntime`. Revert commit `88f51324472b0b3fbd34f8dccb06fe1e8560fbfd` to roll back.

## Follow-up intentionally excluded

Protocol-specific runtime configuration, replacement policy, public service interfaces, and task-backed cleanup ordering are unchanged.