### PR TITLE
ci(security): fail on all reachable vulnerabilities

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -157,6 +157,8 @@ jobs:
           cache: true
       - name: Install govulncheck
         run: go install golang.org/x/vuln/cmd/govulncheck@v1.8.0
+      - name: Verify Hysteria sniff hook remains disabled
+        run: go test -count=1 ./service/hysteria2 -run '^TestBuildServerConfigKeepsVulnerableSniffHookDisabled$'
       - name: Scan reachable vulnerabilities
         shell: bash
         run: |
@@ -175,22 +177,9 @@ jobs:
             exit 0
           fi
 
-          if [[ "$(wc -l < "$affected")" -ne 1 ]] || ! grep -Fxq 'GO-2026-5288' "$affected"; then
-            echo "Reachable vulnerabilities found:" >&2
-            cat "$affected" >&2
-            exit 1
-          fi
-
-          core_version="$(go list -m -f '{{.Version}}' github.com/apernet/hysteria/core/v2)"
-          extras_version="$(go list -m -f '{{.Version}}' github.com/apernet/hysteria/extras/v2)"
-          if ! dpkg --compare-versions "${core_version#v}" ge '2.8.2' \
-            || ! dpkg --compare-versions "${extras_version#v}" ge '2.8.2'; then
-            echo "GO-2026-5288 cannot be allowed with Hysteria core=$core_version extras=$extras_version; both must be at least v2.8.2." >&2
-            exit 1
-          fi
-          go test -count=1 ./service/hysteria2 -run '^TestBuildServerConfigKeepsVulnerableSniffHookDisabled$'
-
-          echo "Allowing GO-2026-5288: the vulnerability database has no fixed version; core=$core_version extras=$extras_version and Hysteria request sniffing remains disabled."
+          echo "Reachable vulnerabilities found:" >&2
+          cat "$affected" >&2
+          exit 1
 
   codeql:
     name: CodeQL

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ Notable user-facing, compatibility, security, performance, and operational chang
 ### Security
 
 - Releases publish platform archives with one signed SHA256 index; per-platform SPDX SBOMs, source mappings, keyless signatures, and GitHub provenance attestations remain generated as workflow evidence.
-- `govulncheck` blocks reachable findings except for a temporary, narrowly validated `GO-2026-5288` allowance: Hysteria core and extras must be at least v2.8.2 and the request-sniff hook must remain disabled.
+- `govulncheck` now fails closed on every reachable vulnerability; the expired `GO-2026-5288` allowance has been removed.
 - Runtime configuration now rejects plaintext HTTP for remote panel API hosts before publishing a candidate; HTTP remains available for loopback development endpoints.
 - Panel adapter parsing errors no longer serialize node or user responses that may contain passwords, UUIDs, protocol keys, or certificate material.
 
@@ -23,7 +23,7 @@ Notable user-facing, compatibility, security, performance, and operational chang
 - Updated the CI vulnerability scanner to govulncheck v1.8.0 so the security gate can analyze the Go 1.27 codebase.
 - Upgraded supported Go, Redis, Hysteria core/extras to v2.12.0, sing, sing-box, artifact, container, stale-issue, and signing dependencies; GitHub Actions remain pinned to full commit SHAs.
 - Updated the Go toolchain to 1.26.6, Hysteria core/extras to v2.12.1, sing to v0.8.13, sing-box to v1.13.18, and refreshed the pinned Alpine and CodeQL maintenance inputs.
-- Updated Hysteria core/extras to v2.12.2 as the latest available patch release; the existing GO-2026-5288 scan exception remains required because the vulnerability database still reports no fixed version.
+- Updated Hysteria core/extras to v2.12.2 as the latest available patch release; reachable vulnerability findings remain release-blocking until a fixed dependency version is available.
 - Docker builds now pin both the Go builder and Alpine runtime images by readable version and multi-platform manifest digest.
 - Controller and machine runtimes now share one Applied node value deep-clone module, preserving nil/empty collection and custom address compatibility semantics.
 - Initial startup and hot reload now use the same mode-specific runtime configuration validation: static mode requires at least one `Nodes` entry, while enabled `MachineConfig` is valid with no static `Nodes`.


### PR DESCRIPTION
## Summary

- remove the expired `GO-2026-5288` exception from the required Govulncheck job
- fail the job for every reachable vulnerability reported as `affected`
- retain the Hysteria `RequestHook: nil` regression test as an independent defense-in-depth check
- update the unreleased security notes to describe the fail-closed release policy

## Verification

- `go test -count=1 ./service/hysteria2 -run '^TestBuildServerConfigKeepsVulnerableSniffHookDisabled$'`
- `go test -count=1 ./...`
- `go vet ./...`
- `go build ./...`
- `go build -tags with_quic .`
- `go mod verify`
- `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.7 .github/workflows/test.yml`
- workflow YAML and extracted Bash syntax validation
- baseline/modified/rollback policy transaction

## Expected required-check state

The current vulnerability database still reports reachable `GO-2026-5288` for Hysteria v2.12.2. After this change, the Govulncheck job is expected to fail closed until the database or dependency provides a fixed version. This PR does not disable Hysteria or weaken the existing sniff-hook guard.