### PR TITLE
ci(security): temporarily allow GO-2026-5288

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -166,7 +166,8 @@ jobs:
 
           report="$(mktemp)"
           affected="$(mktemp)"
-          trap 'rm -f "$report" "$affected"' EXIT
+          unexpected="$(mktemp)"
+          trap 'rm -f "$report" "$affected" "$unexpected"' EXIT
 
           govulncheck -format openvex ./... > "$report"
           jq -r '.statements[]? | select(.status == "affected") | .vulnerability.name' "$report" \
@@ -177,9 +178,22 @@ jobs:
             exit 0
           fi
 
-          echo "Reachable vulnerabilities found:" >&2
-          cat "$affected" >&2
-          exit 1
+          grep -Fxv 'GO-2026-5288' "$affected" > "$unexpected" || true
+          if [[ -s "$unexpected" ]]; then
+            echo "Unexpected reachable vulnerabilities found:" >&2
+            cat "$unexpected" >&2
+            exit 1
+          fi
+
+          core_version="$(go list -m -f '{{.Version}}' github.com/apernet/hysteria/core/v2)"
+          extras_version="$(go list -m -f '{{.Version}}' github.com/apernet/hysteria/extras/v2)"
+          if ! dpkg --compare-versions "${core_version#v}" ge '2.8.2' \
+            || ! dpkg --compare-versions "${extras_version#v}" ge '2.8.2'; then
+            echo "GO-2026-5288 cannot be allowed with Hysteria core=$core_version extras=$extras_version; both must be at least v2.8.2." >&2
+            exit 1
+          fi
+
+          echo "::warning title=Temporary vulnerability allowance::Allowing GO-2026-5288 while Hysteria request sniffing remains disabled; core=$core_version extras=$extras_version."
 
   codeql:
     name: CodeQL

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Notable user-facing, compatibility, security, performance, and operational chang
 
 ## Unreleased
 
+### Security
+
+- Temporarily allowlisted `GO-2026-5288` only when it is the sole reachable finding, Hysteria core and extras remain at least v2.8.2, and the request-sniffing mitigation test passes; every other reachable vulnerability remains release-blocking.
+
 ## 0.9.2 - 2026-09-12
 
 ### Security


### PR DESCRIPTION
## Summary
- temporarily allow GO-2026-5288 only when it is the sole reachable govulncheck finding
- keep the Hysteria request-sniffing mitigation test mandatory
- require Hysteria core and extras v2.8.2 or newer
- continue failing CI for every other reachable vulnerability
- record the temporary allowance under Unreleased

## Verification
- `go test -count=1 ./service/hysteria2 -run '^TestBuildServerConfigKeepsVulnerableSniffHookDisabled$'`
- workflow YAML parsed successfully
- `git diff --check`
