### PR TITLE
fix(release): restore Android arm64 build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -201,6 +201,9 @@ jobs:
             -X github.com/Mtoly/XrayRP/internal/buildinfo.BuildCommit=$COMMIT \
             -X github.com/Mtoly/XrayRP/internal/buildinfo.BuildTime=$BUILD_TIME \
             -X github.com/Mtoly/XrayRP/internal/buildinfo.BuildDirty=false"
+          if [[ "$GOOS" == "android" ]]; then
+            ldflags="$ldflags -checklinkname=0"
+          fi
           go build -v -o build_assets/XrayR -tags with_quic -trimpath -ldflags "$ldflags" .
           if [[ "$GOARCH" == "mips" || "$GOARCH" == "mipsle" ]]; then
             GOMIPS=softfloat go build -v -o build_assets/XrayR_softfloat \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Notable user-facing, compatibility, security, performance, and operational chang
 
 ### Fixed
 
+- Restored Android/arm64 release builds under Go 1.23 and later by enabling the linker compatibility flag required by the Android network-interface dependency.
 - Updated the pinned Docker builder image to Go 1.27.1 so release container builds satisfy the Go 1.27 module requirement.
 
 ## 0.9.2 - 2026-09-12


### PR DESCRIPTION
## Summary

- add the linker compatibility flag required by `github.com/wlynxg/anet` only for Android release targets
- preserve existing linker flags for every other release platform
- document the Android/arm64 release build fix in the changelog

## Root cause

Go 1.23 and later enforce `//go:linkname` checks. The Android implementation in `github.com/wlynxg/anet v0.0.5` references `net.zoneCache` and requires `-checklinkname=0`, causing the release matrix entry to fail with:

```text
link: github.com/wlynxg/anet: invalid reference to net.zoneCache
```

## Verification

- Android/arm64 build without the conditional linker flag reproduces the failure (exit 1)
- Android/arm64 build with the workflow-derived linker flag succeeds (exit 0)
- rollback restores the original workflow SHA-256 and reproduces the original failure
- `go test -count=1 ./...`
- `go vet ./...`
- `go build ./...`
- `go build -tags with_quic .`
- YAML parse and `git diff --check`

No automatic merge is configured.