### PR TITLE
feat(controller): support trusted X-Forwarded-For headers

### DIFF
--- a/panel/panel_machine_test.go
+++ b/panel/panel_machine_test.go
@@ -201,7 +201,8 @@ func TestBuildMachineNodeAPIConfigIncludesMachineID(t *testing.T) {
 
 func TestBuildMachineControllerConfigReturnsFreshConfigPerNode(t *testing.T) {
 	template := &controller.Config{
-		UpdatePeriodic: 45,
+		UpdatePeriodic:       45,
+		TrustedXForwardedFor: []string{"CF-Connecting-IP"},
 		WebSocketConfig: &controller.WebSocketConfig{
 			Enable:            false,
 			Endpoint:          "wss://panel.example.com/ws",
@@ -230,6 +231,13 @@ func TestBuildMachineControllerConfigReturnsFreshConfigPerNode(t *testing.T) {
 	if cfg1 == cfg2 {
 		t.Fatal("expected fresh top-level controller configs")
 	}
+	if len(cfg1.TrustedXForwardedFor) != 1 || cfg1.TrustedXForwardedFor[0] != "CF-Connecting-IP" || len(cfg2.TrustedXForwardedFor) != 1 || cfg2.TrustedXForwardedFor[0] != "CF-Connecting-IP" {
+		t.Fatalf("expected TrustedXForwardedFor to propagate, got %#v and %#v", cfg1.TrustedXForwardedFor, cfg2.TrustedXForwardedFor)
+	}
+	if cfg1.TrustedXForwardedFor == nil || &cfg1.TrustedXForwardedFor[0] == &cfg2.TrustedXForwardedFor[0] {
+		t.Fatal("expected independent TrustedXForwardedFor slices")
+	}
+
 	if cfg1.UpdatePeriodic != template.UpdatePeriodic || cfg2.UpdatePeriodic != template.UpdatePeriodic {
 		t.Fatalf("expected UpdatePeriodic %d, got %d and %d", template.UpdatePeriodic, cfg1.UpdatePeriodic, cfg2.UpdatePeriodic)
 	}

--- a/release/config/config.yml.example
+++ b/release/config/config.yml.example
@@ -35,6 +35,10 @@ Observability: # Optional local health, readiness, and Prometheus metrics server
 #   ControllerConfig: # Shared controller defaults applied to every discovered server/node.
 #     ListenIP: 0.0.0.0 # Local listen IP for inbound services created from discovered nodes.
 #     SendIP: 0.0.0.0 # Local outbound source IP. Use 0.0.0.0 for the system default.
+#     # Trusted HTTP header names for X-Forwarded-For; empty by default. Use names, not IPs/CIDRs.
+#     # Example: CF-Connecting-IP. Header presence only; restrict origin access to trusted proxies/CDNs.
+#     TrustedXForwardedFor:
+#       - CF-Connecting-IP
 #     UpdatePeriodic: 60 # Fallback per-node interval; panel pull_interval has a 30s minimum and push_interval has a 5s minimum.
 #     WebSocketConfig: # Shared machine WebSocket control-plane settings.
 #       Enable: true # Enable shared machine WebSocket for sync.nodes, per-node mailbox routing, and node.status reports.
@@ -59,6 +63,10 @@ Nodes: # Static node list. Use this when MachineConfig is disabled.
     ControllerConfig: # Runtime behavior for this node.
       ListenIP: 0.0.0.0 # Local IP address for inbound listeners.
       SendIP: 0.0.0.0 # Local outbound source IP. Use 0.0.0.0 for the system default.
+      # Trusted HTTP header names for X-Forwarded-For; empty by default. Use names, not IPs/CIDRs.
+      # Example: CF-Connecting-IP. This checks header presence only; restrict origin access to trusted proxies/CDNs.
+      TrustedXForwardedFor:
+        - CF-Connecting-IP
       UpdatePeriodic: 60 # Local fallback interval. Xboard pull_interval controls sync (minimum 30s) and push_interval controls reports (minimum 5s) when provided.
       EnableDNS: false # Enable custom DNS config from DnsConfigPath.
       DNSType: AsIs # DNS strategy: AsIs, UseIP, UseIPv4, or UseIPv6.

--- a/service/controller/config.go
+++ b/service/controller/config.go
@@ -15,6 +15,7 @@ type Config struct {
 	DisableUploadTraffic      bool                             `mapstructure:"DisableUploadTraffic"`
 	DisableGetRule            bool                             `mapstructure:"DisableGetRule"`
 	EnableProxyProtocol       bool                             `mapstructure:"EnableProxyProtocol"`
+	TrustedXForwardedFor      []string                         `mapstructure:"TrustedXForwardedFor"`
 	EnableFallback            bool                             `mapstructure:"EnableFallback"`
 	DisableIVCheck            bool                             `mapstructure:"DisableIVCheck"`
 	DisableSniffing           bool                             `mapstructure:"DisableSniffing"`

--- a/service/controller/config_clone.go
+++ b/service/controller/config_clone.go
@@ -20,6 +20,7 @@ func (config *Config) Clone() *Config {
 	cloned.FallBackConfigs = cloneFallBackConfigs(config.FallBackConfigs)
 	cloned.REALITYConfigs = cloneLocalREALITYConfig(config.REALITYConfigs)
 	cloned.WebSocketConfig = cloneWebSocketConfig(config.WebSocketConfig)
+	cloned.TrustedXForwardedFor = cloneSlice(config.TrustedXForwardedFor)
 	return &cloned
 }
 

--- a/service/controller/config_clone_test.go
+++ b/service/controller/config_clone_test.go
@@ -82,6 +82,7 @@ func TestConfigCloneDetachesNestedValues(t *testing.T) {
 			MaxTimeDiff:      60,
 			ShortIds:         []string{"short-id"},
 		},
+		TrustedXForwardedFor: []string{"CF-Connecting-IP"},
 		WebSocketConfig: &WebSocketConfig{
 			Enable:            true,
 			Endpoint:          "wss://panel.example/ws",
@@ -119,7 +120,11 @@ func TestConfigCloneDetachesNestedValues(t *testing.T) {
 	cloned.REALITYConfigs.ServerNames[0] = "clone.example.com"
 	cloned.REALITYConfigs.ShortIds[0] = "clone-short-id"
 	cloned.WebSocketConfig.Endpoint = "wss://clone.example/ws"
+	cloned.TrustedXForwardedFor[0] = "clone-header"
 
+	if original.TrustedXForwardedFor[0] != "CF-Connecting-IP" {
+		t.Fatalf("trusted forwarded headers were aliased: %#v", original.TrustedXForwardedFor)
+	}
 	if original.CertConfig.DNSEnv["DNS_TOKEN"] != "source-token" || original.CertConfig.CertFile != "/tmp/node.crt" {
 		t.Fatalf("certificate config was aliased: %#v", original.CertConfig)
 	}

--- a/service/controller/inboundbuilder.go
+++ b/service/controller/inboundbuilder.go
@@ -459,16 +459,33 @@ func buildInbound(config *Config, node inboundNodeView, tag string) (*core.Inbou
 		streamSetting.TLSSettings = tlsSettings
 	}
 
-	// Support ProxyProtocol for any transport protocol
-	if networkType != "tcp" && networkType != "ws" && (config.EnableProxyProtocol || node.transport.acceptProxyProtocol) {
-		sockoptConfig := &conf.SocketConfig{
-			AcceptProxyProtocol: config.EnableProxyProtocol || node.transport.acceptProxyProtocol,
+	// Support ProxyProtocol for any transport protocol without replacing existing socket settings.
+	acceptProxyProtocol := config.EnableProxyProtocol || node.transport.acceptProxyProtocol
+	if networkType != "tcp" && networkType != "ws" && acceptProxyProtocol {
+		if streamSetting.SocketSettings == nil {
+			streamSetting.SocketSettings = &conf.SocketConfig{}
 		}
-		streamSetting.SocketSettings = sockoptConfig
+		streamSetting.SocketSettings.AcceptProxyProtocol = acceptProxyProtocol
 	}
+	if supportsTrustedXForwardedFor(networkType) && len(config.TrustedXForwardedFor) > 0 {
+		if streamSetting.SocketSettings == nil {
+			streamSetting.SocketSettings = &conf.SocketConfig{}
+		}
+		streamSetting.SocketSettings.TrustedXForwardedFor = cloneSlice(config.TrustedXForwardedFor)
+	}
+
 	inboundDetourConfig.StreamSetting = streamSetting
 
 	return inboundDetourConfig.Build()
+}
+
+func supportsTrustedXForwardedFor(networkType string) bool {
+	switch networkType {
+	case "websocket", "httpupgrade", "grpc", "splithttp":
+		return true
+	default:
+		return false
+	}
 }
 
 func mergeSplitHTTPExtra(explicit *conf.SplitHTTPConfig) (*conf.SplitHTTPConfig, error) {

--- a/service/controller/inboundbuilder_test.go
+++ b/service/controller/inboundbuilder_test.go
@@ -213,3 +213,61 @@ func TestInboundBuilderPrefersCompletePanelREALITYConfig(t *testing.T) {
 		t.Fatalf("expected panel REALITY settings, got dest %q xver %d", realityConfig.Dest, realityConfig.Xver)
 	}
 }
+
+func TestInboundBuilderTrustedXForwardedFor(t *testing.T) {
+	transports := []struct {
+		name     string
+		protocol string
+	}{
+		{"xhttp", "xhttp"}, {"websocket", "ws"}, {"httpupgrade", "httpupgrade"}, {"grpc", "grpc"},
+	}
+	for _, tt := range transports {
+		t.Run(tt.name, func(t *testing.T) {
+			node := &api.NodeInfo{NodeType: "V2ray", Port: 8443, TransportProtocol: tt.protocol, EnableVless: true}
+			inbound, err := InboundBuilder(&Config{TrustedXForwardedFor: []string{"CF-Connecting-IP"}}, node, "test")
+			if err != nil {
+				t.Fatal(err)
+			}
+			receiver, err := inbound.ReceiverSettings.GetInstance()
+			if err != nil {
+				t.Fatal(err)
+			}
+			settings := receiver.(*proxyman.ReceiverConfig).StreamSettings
+			if settings.SocketSettings == nil || len(settings.SocketSettings.TrustedXForwardedFor) != 1 || settings.SocketSettings.TrustedXForwardedFor[0] != "CF-Connecting-IP" {
+				t.Fatalf("socket settings = %#v", settings.SocketSettings)
+			}
+		})
+	}
+}
+
+func TestInboundBuilderTrustedXForwardedForPreservesProxyProtocol(t *testing.T) {
+	node := &api.NodeInfo{NodeType: "V2ray", Port: 8443, TransportProtocol: "xhttp", EnableVless: true, AcceptProxyProtocol: true}
+	inbound, err := InboundBuilder(&Config{EnableProxyProtocol: true, TrustedXForwardedFor: []string{"CF-Connecting-IP"}}, node, "test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	receiver, err := inbound.ReceiverSettings.GetInstance()
+	if err != nil {
+		t.Fatal(err)
+	}
+	settings := receiver.(*proxyman.ReceiverConfig).StreamSettings
+	if settings.SocketSettings == nil || !settings.SocketSettings.AcceptProxyProtocol || len(settings.SocketSettings.TrustedXForwardedFor) != 1 {
+		t.Fatalf("socket settings = %#v", settings.SocketSettings)
+	}
+}
+
+func TestInboundBuilderTrustedXForwardedForDefault(t *testing.T) {
+	node := &api.NodeInfo{NodeType: "V2ray", Port: 8443, TransportProtocol: "xhttp", EnableVless: true}
+	inbound, err := InboundBuilder(&Config{}, node, "test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	receiver, err := inbound.ReceiverSettings.GetInstance()
+	if err != nil {
+		t.Fatal(err)
+	}
+	settings := receiver.(*proxyman.ReceiverConfig).StreamSettings
+	if settings.SocketSettings != nil {
+		t.Fatalf("socket settings = %#v, want nil", settings.SocketSettings)
+	}
+}


### PR DESCRIPTION
## Summary

Adds configurable support for Xray-core's `streamSettings.sockopt.trustedXForwardedFor` for HTTP-based inbound transports.

## Background

Recent Xray-core versions apply trusted X-Forwarded-For handling for WebSocket, HTTPUpgrade, gRPC, and SplitHTTP/XHTTP. XrayRP previously did not populate `SocketConfig.TrustedXForwardedFor`, so Xray ignored XFF and used the reverse proxy/CDN TCP peer address instead.

## Changes

- Add `ControllerConfig.TrustedXForwardedFor`
- Propagate it to Xray `SocketConfig`
- Support WebSocket, HTTPUpgrade, gRPC, and SplitHTTP/XHTTP
- Preserve existing Proxy Protocol behavior
- Deep-clone the configured header list
- Add Machine mode controller-config propagation regression coverage
- Add inbound builder tests
- Document configuration and security considerations

## Configuration

```yaml
ControllerConfig:
  TrustedXForwardedFor:
    - CF-Connecting-IP
```

The values are trusted HTTP header names, not IP addresses or CIDR ranges. Cloudflare's `CF-Connecting-IP` is only an example.

This setting checks for the configured marker header; it does not verify that the TCP peer actually belongs to Cloudflare or another CDN. Production origins should still be restricted to trusted proxies/CDNs using firewall, security-group, or reverse-proxy controls.

## Backward compatibility

When `TrustedXForwardedFor` is not configured, behavior remains unchanged. Existing Proxy Protocol handling remains unchanged.

## Tests

- XHTTP default behavior
- XHTTP trusted XFF
- XHTTP trusted XFF plus Proxy Protocol
- WebSocket, HTTPUpgrade, and gRPC
- Config clone isolation
- Machine mode controller config propagation

Validation:

```text
go test -count=1 ./service/controller ./panel
go test -count=1 ./...
go vet ./...
go build ./...
git diff --check
```